### PR TITLE
BaseColorのデフォルト値をBaseLightに変更

### DIFF
--- a/TweetGazer/App.config
+++ b/TweetGazer/App.config
@@ -35,7 +35,7 @@
         <value>0</value>
       </setting>
       <setting name="BaseColorIndex" serializeAs="String">
-        <value>1</value>
+        <value>0</value>
       </setting>
       <setting name="IsUpdateCheck" serializeAs="String">
         <value>False</value>

--- a/TweetGazer/Properties/Settings.Designer.cs
+++ b/TweetGazer/Properties/Settings.Designer.cs
@@ -61,7 +61,7 @@ namespace TweetGazer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
         public int BaseColorIndex {
             get {
                 return ((int)(this["BaseColorIndex"]));

--- a/TweetGazer/Properties/Settings.settings
+++ b/TweetGazer/Properties/Settings.settings
@@ -12,7 +12,7 @@
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="BaseColorIndex" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">1</Value>
+      <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="IsUpdateCheck" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>


### PR DESCRIPTION
## 概要
#17 ベースカラーの初期値をBaseLightに

## 変更箇所
* BaseColorIndexが1(BaseDark)になったままだったため0(BaseLight)に修正

## レビュー箇所
