### PR TITLE
タイマーでのTL読み込みが重複しないように

### DIFF
--- a/TweetGazer/Models/TimelineModel.cs
+++ b/TweetGazer/Models/TimelineModel.cs
@@ -789,6 +789,8 @@ namespace TweetGazer.Models
                 return;
             }
 
+            this.IsLoading = true;
+
             try
             {
                 var loadedTimeline = await AccountTokens.LoadListTimelineAsync(this.Data.TokenSuffix, this.Data.CurrentPage.ListNumber, null, this.Data.SinceId);
@@ -801,6 +803,8 @@ namespace TweetGazer.Models
             {
                 DebugConsole.Write(ex);
             }
+
+            this.IsLoading = false;
         }
 
         /// <summary>
@@ -814,6 +818,8 @@ namespace TweetGazer.Models
             {
                 return;
             }
+
+            this.IsLoading = true;
 
             try
             {
@@ -853,6 +859,8 @@ namespace TweetGazer.Models
             {
                 DebugConsole.Write(ex);
             }
+
+            this.IsLoading = false;
         }
 
         /// <summary>
@@ -867,6 +875,8 @@ namespace TweetGazer.Models
                 return;
             }
 
+            this.IsLoading = true;
+
             try
             {
                 var loadedTrend = await AccountTokens.LoadTrendsAsync(this.Data.TokenSuffix);
@@ -879,6 +889,8 @@ namespace TweetGazer.Models
             {
                 DebugConsole.Write(ex);
             }
+
+            this.IsLoading = false;
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要
#26 重複してツイートが読み込まれる場合がある

## 変更箇所
* タイマーで読み込んでいるTL(リスト/ユーザー/トレンド)の読み込み処理が重複して発生しないように変更した

## レビュー箇所
