### PR TITLE
タッチスクロール対応

### DIFF
--- a/TweetGazer/Resources/Dictionaries/Application/ApplicationResources.xaml
+++ b/TweetGazer/Resources/Dictionaries/Application/ApplicationResources.xaml
@@ -1,20 +1,21 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <ResourceDictionary.MergedDictionaries>
-        <!--  Style  -->
-        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Styles/Styles.xaml" />
-
-        <!--  Converter  -->
-        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Convertors/Convertors.xaml" />
-
-        <!--  Icons  -->
-        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Icons/VectorImages.xaml" />
-
         <!--  MahApps.Metro  -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/FlatSlider.xaml" />
+
+        <!--  Style  -->
+        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Styles/Button.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Styles/ScrollViewer.xaml" />
+
+        <!--  Converter  -->
+        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Convertors/Convertors.xaml" />
+
+        <!--  Icons  -->
+        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Icons/VectorImages.xaml" />
 
         <!--  AddTimelineExtraGrid  -->
         <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/AddTimelineExtraGrid/Lists.xaml" />

--- a/TweetGazer/Resources/Dictionaries/Application/Styles/ScrollViewer.xaml
+++ b/TweetGazer/Resources/Dictionaries/Application/Styles/ScrollViewer.xaml
@@ -1,0 +1,5 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style TargetType="{x:Type ScrollViewer}">
+        <Setter Property="ScrollViewer.PanningMode" Value="VerticalOnly" />
+    </Style>
+</ResourceDictionary>

--- a/TweetGazer/Resources/Dictionaries/Application/Styles/Styles.xaml
+++ b/TweetGazer/Resources/Dictionaries/Application/Styles/Styles.xaml
@@ -1,5 +1,0 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/Resources/Dictionaries/Application/Styles/Button.xaml" />
-    </ResourceDictionary.MergedDictionaries>
-</ResourceDictionary>

--- a/TweetGazer/TweetGazer.csproj
+++ b/TweetGazer/TweetGazer.csproj
@@ -335,7 +335,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Resources\Dictionaries\Application\Styles\Styles.xaml">
+    <Page Include="Resources\Dictionaries\Application\Styles\ScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
## 概要
close #45 

## 変更箇所
* ScrollViewerにデフォルトで `ScrollViewer.PanningMode=VerticalOnly` を指定
* Style.xamlを削除
* 上書き回避のため、ApplicationResouces.xamlの記述順を変更

## レビュー箇所
